### PR TITLE
perf(backend): Registering Cloud Logging as a global module

### DIFF
--- a/packages/backend/src/core/LoggerService.ts
+++ b/packages/backend/src/core/LoggerService.ts
@@ -8,22 +8,23 @@ import { DI } from '@/di-symbols.js';
 import type { Config } from '@/config.js';
 import Logger from '@/logger.js';
 import { bindThis } from '@/decorators.js';
+import type { Logging } from '@google-cloud/logging';
 import type { KEYWORD } from 'color-convert/conversions.js';
 
 @Injectable()
 export class LoggerService {
-	private cloudLogging;
 	constructor(
 		@Inject(DI.config)
 		private config: Config,
+
+		@Inject(DI.cloudLogging)
+		private cloudLogging: Logging | null,
 	) {
-		if (this.config.cloudLogging) {
-			this.cloudLogging = this.config.cloudLogging;
-		}
 	}
 
 	@bindThis
 	public getLogger(domain: string, color?: KEYWORD | undefined, store?: boolean) {
-		return new Logger(domain, color, store, this.cloudLogging);
+		const logger = this.cloudLogging?.log(this.config.cloudLogging?.logName ?? 'cherrypick');
+		return new Logger(domain, color, store, logger);
 	}
 }

--- a/packages/backend/src/di-symbols.ts
+++ b/packages/backend/src/di-symbols.ts
@@ -7,6 +7,7 @@ export const DI = {
 	config: Symbol('config'),
 	db: Symbol('db'),
 	meilisearch: Symbol('meilisearch'),
+	cloudLogging: Symbol('cloudLogging'),
 	redis: Symbol('redis'),
 	redisForPub: Symbol('redisForPub'),
 	redisForSub: Symbol('redisForSub'),

--- a/packages/backend/src/logger.ts
+++ b/packages/backend/src/logger.ts
@@ -8,10 +8,10 @@ import util from 'util';
 import chalk from 'chalk';
 import { default as convertColor } from 'color-convert';
 import { format as dateFormat } from 'date-fns';
-import { Logging } from '@google-cloud/logging';
 import stripAnsi from 'strip-ansi';
 import { bindThis } from '@/decorators.js';
 import { envOption } from './env.js';
+import type { Log } from '@google-cloud/logging';
 import type { KEYWORD } from 'color-convert/conversions.js';
 
 type Context = {
@@ -20,21 +20,20 @@ type Context = {
 };
 
 type Level = 'error' | 'success' | 'warning' | 'debug' | 'info';
-type CloudLogging = any | undefined;
 
 export default class Logger {
 	private context: Context;
 	private parentLogger: Logger | null = null;
 	private store: boolean;
-	private clConfig?: CloudLogging;
+	private cloudLogging: Log | null | undefined;
 
-	constructor(context: string, color?: KEYWORD, store = true, clConfig?: CloudLogging) {
+	constructor(context: string, color?: KEYWORD, store = true, cloudLogging?: Log) {
 		this.context = {
 			name: context,
 			color: color,
 		};
 		this.store = store;
-		this.clConfig = clConfig;
+		this.cloudLogging = cloudLogging;
 	}
 
 	@bindThis
@@ -87,16 +86,12 @@ export default class Logger {
 	}
 
 	private async writeCloudLogging(level: Level, message: string, time: Date, data?: Record<string, any> | null) {
-		if (!this.clConfig) return;
-		if (!this.clConfig.projectId || !this.clConfig.saKeyPath) return;
+		if (!this.cloudLogging) return;
 
 		let lv = level;
 		if (level === 'success') lv = 'info';
 
-		const projectId = this.clConfig.projectId;
-		const logging = new Logging({ projectId: projectId, keyFilename: this.clConfig.saKeyPath });
-		const logName = this.clConfig.logName ?? 'cherrypick';
-		const log = logging.log(logName);
+		const log = this.cloudLogging;
 		const logMessage = stripAnsi(message);
 
 		const metadata = {


### PR DESCRIPTION
## What
Commit for expecting performance improvement in existing Cloud Logging.

## Why
I belatedly registered it in the GlobalModule due to the perceived heavy overhead of Cloud Logging.

## Additional info (optional)
🎉 #80
(Actually, I have no way of knowing if there has been a complete improvement...??)

## Checklist
- [x] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
