### PR TITLE
fix: migration is not applied properly

### DIFF
--- a/packages/backend/migration/1660183643857-multipleTranslationServices.js
+++ b/packages/backend/migration/1660183643857-multipleTranslationServices.js
@@ -11,7 +11,7 @@ export class multipleTranslationServices1660183643857 {
 				await queryRunner.query('SELECT "deeplAuthKey" FROM "meta" where "deeplAuthKey" is not null')
 				.then(deeplAuthKey => {
 					if (deeplAuthKey.length > 0) {
-						return queryRunner.query(`UPDATE "meta" SET "translatorType" = 'DeepL'`);
+						return queryRunner.query(`UPDATE "meta" SET "translatorType" = 'deepl'`);
 					}
 				})
     }


### PR DESCRIPTION
## What
Fix translate option when migrated from misskey instance with DeepL key.

## Why
translate option is not working after migration

## Checklist
- [x] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
