### PR TITLE
fix(frontend): cannot steal emoji from reaction viewer

### DIFF
--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -66,6 +66,12 @@ const reactionName = computed(() => {
 	return r.slice(0, r.indexOf('@'));
 });
 
+const reactionHost = computed(() => {
+	const r = props.reaction.replace(':', '');
+	const host = r.slice(r.indexOf('@') + 1);
+	return host.endsWith('.') ? host.slice(0, -1) : host;
+});
+
 const alternative: ComputedRef<string | null> = computed(() => defaultStore.state.reactableRemoteReactionEnabled ? (customEmojis.value.find(it => it.name === reactionName.value)?.name ?? null) : null);
 
 async function toggleReaction(ev: MouseEvent) {

--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -137,7 +137,7 @@ function stealReaction(ev: MouseEvent) {
 		action: async () => {
 			await os.apiWithDialog('admin/emoji/steal', {
 				name: reactionName.value,
-				host: props.note.user.host,
+				host: reactionHost.value,
 			});
 		},
 	}, {
@@ -146,7 +146,7 @@ function stealReaction(ev: MouseEvent) {
 		action: async () => {
 			await os.apiWithDialog('admin/emoji/steal', {
 				name: reactionName.value,
-				host: props.note.user.host,
+				host: reactionHost.value,
 			});
 
 			await misskeyApi('notes/reactions/create', {


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
リアクションビューワーから絵文字をインポートしようとする場合、インポートできないのを修正

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
close #487 

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->
今回はミスではないです。
API側に不具合がないことも確認しています。

## Checklist
- [x] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
