### PR TITLE
Fix #560 add custom emoji broken

### DIFF
--- a/packages/backend/src/core/CustomEmojiService.ts
+++ b/packages/backend/src/core/CustomEmojiService.ts
@@ -105,15 +105,6 @@ export class CustomEmojiService implements OnApplicationShutdown {
 		localOnly: boolean;
 		roleIdsThatCanBeUsedThisEmojiAsReaction: MiRole['id'][];
 	}, moderator?: MiUser): Promise<MiEmoji> {
-		// システムユーザーとして再アップロード
-		if (!data.driveFile.user?.isRoot) {
-			data.driveFile = await this.driveService.uploadFromUrl({
-				url: data.driveFile.url,
-				user: null,
-				force: true,
-			});
-		}
-
 		const emoji = await this.emojisRepository.insertOne({
 			id: this.idService.gen(),
 			updatedAt: new Date(),


### PR DESCRIPTION
## What
driveFile은 리팩토링으로 더이상 사용되지 않아 관련 코드를 전부 삭제했습니다.

driveFile usage was removed and not used at all, so I removed entire code block.

driveFileの使用は削除され、まったく使われていなかったので、コードブロック全体を削除した。

## Why
#560 수정
Fix #560

## Additional info (optional)

## Checklist
- [x] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
