### PR TITLE
Fix: 개행으로 메시지가 전송되는 버그와 더 보기 버튼이 작동하지 않는 문제 수정

### DIFF
--- a/CHANGELOG_CHERRYPICK.md
+++ b/CHANGELOG_CHERRYPICK.md
@@ -11,7 +11,8 @@ Misskey의 전체 변경 사항을 확인하려면, [CHANGELOG.md#2025xx](CHANGE
 - 
 
 ### Client
-- 
+- Fix: 더 보기 버튼이 작동하지 않는 문제 수정
+- Fix: 개행으로 메시지가 전송되는 버그 수정
 
 ### Server
 - 

--- a/packages/frontend/src/components/MkPagination.vue
+++ b/packages/frontend/src/components/MkPagination.vue
@@ -246,7 +246,7 @@ const fetchMore = async (): Promise<void> => {
 		...(props.pagination.offsetMode ? {
 			offset: items.value.size,
 		} : {
-			untilId: Array.from(items.value.keys()).at(-1),
+			untilId: Array.from(items.value.keys()).pop(),
 		}),
 	}).then(res => {
 		for (let i = 0; i < res.length; i++) {
@@ -309,7 +309,7 @@ const fetchMoreAhead = async (): Promise<void> => {
 		...(props.pagination.offsetMode ? {
 			offset: items.value.size,
 		} : {
-			sinceId: Array.from(items.value.keys()).at(-1),
+			untilId: Array.from(items.value.keys()).pop(),
 		}),
 	}).then(res => {
 		if (res.length === 0) {

--- a/packages/frontend/src/components/MkPagination.vue
+++ b/packages/frontend/src/components/MkPagination.vue
@@ -76,6 +76,8 @@ export type Paging<E extends keyof Misskey.Endpoints = keyof Misskey.Endpoints> 
 
 	offsetMode?: boolean;
 
+	isMessaging?: boolean;
+
 	pageEl?: HTMLElement;
 };
 
@@ -246,7 +248,7 @@ const fetchMore = async (): Promise<void> => {
 		...(props.pagination.offsetMode ? {
 			offset: items.value.size,
 		} : {
-			untilId: Array.from(items.value.keys()).pop(),
+			untilId: Array.from(items.value.keys()).at(-1),
 		}),
 	}).then(res => {
 		for (let i = 0; i < res.length; i++) {
@@ -308,8 +310,10 @@ const fetchMoreAhead = async (): Promise<void> => {
 		limit: SECOND_FETCH_LIMIT,
 		...(props.pagination.offsetMode ? {
 			offset: items.value.size,
+		} : props.pagination.isMessaging ? {
+			untilId: Array.from(items.value.keys()).at(-1),
 		} : {
-			untilId: Array.from(items.value.keys()).pop(),
+			untilId: Array.from(items.value.keys()).at(-1),
 		}),
 	}).then(res => {
 		if (res.length === 0) {

--- a/packages/frontend/src/components/MkPagination.vue
+++ b/packages/frontend/src/components/MkPagination.vue
@@ -313,7 +313,7 @@ const fetchMoreAhead = async (): Promise<void> => {
 		} : props.pagination.isMessaging ? {
 			untilId: Array.from(items.value.keys()).at(-1),
 		} : {
-			untilId: Array.from(items.value.keys()).at(-1),
+			sinceId: Array.from(items.value.keys()).at(-1),
 		}),
 	}).then(res => {
 		if (res.length === 0) {

--- a/packages/frontend/src/pages/messaging/messaging-room.form.vue
+++ b/packages/frontend/src/pages/messaging/messaging-room.form.vue
@@ -67,7 +67,7 @@ const typing = () => {
 };
 
 const draftKey = computed(() => props.user ? 'user:' + props.user.id : 'group:' + props.group?.id);
-const canSend = computed(() => (text.value.trim() !== '') || file.value != null);
+const canSend = computed(() => text.value.trim() !== '' || file.value != null);
 
 watch([text.value, file.value], saveDraft);
 

--- a/packages/frontend/src/pages/messaging/messaging-room.form.vue
+++ b/packages/frontend/src/pages/messaging/messaging-room.form.vue
@@ -67,7 +67,7 @@ const typing = () => {
 };
 
 const draftKey = computed(() => props.user ? 'user:' + props.user.id : 'group:' + props.group?.id);
-const canSend = computed(() => (text.value != null && text.value !== '') || file.value != null);
+const canSend = computed(() => (text.value.trim() !== '') || file.value != null);
 
 watch([text.value, file.value], saveDraft);
 


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

**수정 내용:**

1. **개행으로 메시지가 전송되는 버그 수정**  
   메시지를 입력할 때 개행을 사용하더라도 전송 버튼을 눌러야만 개행이 반영되는 것이 정상입니다. 그러나 어떤 이유로 개행이 그대로 전송되는 버그가 발생했습니다. 이 버그를 수정함으로써, 개행이 텍스트 영역 내에서 정상적으로 반영되고, 메시지가 전송될 때 개행 없이 전송됩니다.

2. **더 보기 버튼이 작동하지 않는 문제 수정**  
   '더 보기' 버튼이 기능하지 않던 문제도 수정되었습니다. 이 버튼은 클릭하면 더 많은 콘텐츠가 표시되는 기능인데, 어떤 이유로 이 기능이 중단되었었습니다. 이 문제를 해결함으로써, '더 보기' 버튼이 정상적으로 작동하여 사용자가 더 많은 콘텐츠를 볼 수 있게 됩니다.


## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
