### PR TITLE
非ログインでローカル/グローバルタイムラインが表示できない不具合の修正

### DIFF
--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -104,7 +104,7 @@ window.addEventListener('resize', () => {
 	isMobile.value = deviceKind === 'smartphone' || window.innerWidth <= MOBILE_THRESHOLD;
 });
 
-const schedulePostList = (await misskeyApi('notes/schedule/list')).length;
+const schedulePostList = $i ? (await misskeyApi('notes/schedule/list')).length : 0;
 
 if (!isFriendly.value) provide('shouldOmitHeaderTitle', true);
 


### PR DESCRIPTION
## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ログインしていない時に`/api/notes/schedule/list`を呼ばないようにします

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
ログインしていない状態で`/timeline`が表示できなくなっている問題を修正します

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
