### PR TITLE
에러 이미지 표시 오류 해결

### DIFF
--- a/packages/frontend/src/pages/_error_.vue
+++ b/packages/frontend/src/pages/_error_.vue
@@ -82,7 +82,7 @@ definePage(() => ({
 .img {
 	vertical-align: bottom;
 	height: 128px;
-	margin-bottom: 24px;
+	margin: auto;
 	border-radius: 16px;
 }
 </style>


### PR DESCRIPTION
에러 이미지 표시오류 해결

<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

에러 이미지가 눌려서 표시되는 오류 해결입니다.
margin-bottom을 margin: auto 로 변경하면 자동으로 가운데에 맞춰서 정렬됩니다.

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Before: 아래 이미지
![image](https://github.com/user-attachments/assets/8fae0c1c-b0b2-49da-b6ad-1d127efa0417)

After: 아래 이미지
![image](https://github.com/user-attachments/assets/dfac7e20-8537-40db-b89f-9555051e4eff)


## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [V] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [V] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
